### PR TITLE
allow to specify contents of files instead of providing files

### DIFF
--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -17,6 +17,15 @@
 # [*bundlefile*]
 #   Full name of the bundle file, including the file extension. For example 
 #   'ca-bundle.crt'. Defaults to undef, meaning that a bundle is not installed.
+# [*bundlefile_content*]
+#   Full content of the bundle file. If not present, the bundle is taken from
+#   puppet:///files/${bundlefile}.
+# [*certfile_content*]
+#   Full content of the certificate. If not present, the certificate is taken from
+#   puppet:///files/sslcert-${title}.crt.
+# [*keyfile_content*]
+#   Full content of the private key. If not present, the key is taken from
+#   puppet:///files/sslcert-${title}.key.
 # [*embed_bundle*]
 #   Whether to combine the bundle with the certificate. Valid values are true 
 #   and false. This must be true for nginx and false for apache2. Defaults to 
@@ -26,6 +35,9 @@ define sslcert::set
 (
     Enum['present','absent'] $ensure = 'present',
     Optional[String]         $bundlefile = undef,
+    Optional[String]         $bundlefile_content = undef,
+    Optional[String]         $certfile_content = undef,
+    Optional[String]         $keyfile_content = undef,
     Boolean                  $embed_bundle = false
 )
 {
@@ -34,19 +46,49 @@ define sslcert::set
     $basename = $title
     $keyfile = "${basename}.key"
     $certfile = "${basename}.crt"
+    $certfile_attr = {
+        'ensure' => $ensure,
+        'owner'  => $::sslcert::params::owner,
+        'group'  => $::sslcert::params::cert_group,
+        'mode'   => $::sslcert::params::cert_mode,
+    }
 
     # The key will always be installed as-is
     file { "sslcert-${keyfile}":
         ensure => $ensure,
         name   => "${::sslcert::params::keydir}/${keyfile}",
-        source => "puppet:///files/sslcert-${keyfile}", # lint:ignore:puppet_url_without_modules
-
         owner  => $::sslcert::params::owner,
         group  => $::sslcert::params::private_key_group,
         mode   => $::sslcert::params::private_key_mode,
     }
+    if $keyfile_content {
+        File["sslcert-${keyfile}"] {
+            content => $keyfile_content,
+        }
+    } else {
+        File["sslcert-${keyfile}"] {
+            source => "puppet:///files/sslcert-${keyfile}", # lint:ignore:puppet_url_without_modules
+        }
+    }
 
-    # We might not need a CA bundle if the existing ones are enough, or if we're 
+    unless $embed_bundle {
+        file { "sslcert-${certfile}":
+            name => "${::sslcert::params::certdir}/${certfile}",
+            *    => $certfile_attr,
+        }
+        if $certfile_content {
+            File["sslcert-${certfile}"] {
+                content => $certfile_content,
+            }
+        } else {
+            File["sslcert-${certfile}"] {
+                source => "puppet:///files/sslcert-${certfile}", # lint:ignore:puppet_url_without_modules
+            }
+        }
+    }
+
+
+    # We might not need a CA bundle if the existing ones are enough, or if we're
     # installing self-signed certificates.
     if $bundlefile {
 
@@ -56,54 +98,52 @@ define sslcert::set
             $target = "sslcert-${basename}-cert-and-bundle"
 
             concat { $target:
-                ensure => $ensure,
-                path   => "${::sslcert::params::certdir}/${certfile}",
-                owner  => $::sslcert::params::owner,
-                group  => $::sslcert::params::cert_group,
-                mode   => $::sslcert::params::cert_mode,
+                path => "${::sslcert::params::certdir}/${certfile}",
+                *    => $certfile_attr,
             }
-            concat::fragment { "sslcert-${basename}-cert":
-                source => "puppet:///files/sslcert-${certfile}", # lint:ignore:puppet_url_without_modules
-
-                # The certificate must be placed at the head
-                order  => '1',
-                target => $target,
+            if $certfile_content {
+                concat::fragment { "sslcert-${basename}-cert":
+                    content => $certfile_content,
+                    # The certificate must be placed at the head
+                    order   => '1',
+                    target  => $target,
+                }
+            } else {
+                concat::fragment { "sslcert-${basename}-cert":
+                    source => "puppet:///files/sslcert-${certfile}", # lint:ignore:puppet_url_without_modules
+                    # The certificate must be placed at the head
+                    order  => '1',
+                    target => $target,
+                }
             }
-            concat::fragment { "sslcert-${basename}-bundle":
-                source => "puppet:///files/${bundlefile}", # lint:ignore:puppet_url_without_modules
+            if $bundlefile_content {
+                concat::fragment { "sslcert-${basename}-bundle":
+                    content => $bundlefile_content,
+                    order   => '2',
+                    target  => $target,
+                }
+            } else {
+                concat::fragment { "sslcert-${basename}-bundle":
+                    source => "puppet:///files/${bundlefile}", # lint:ignore:puppet_url_without_modules
+                    order  => '2',
+                    target => $target,
 
-                order  => '2',
-                target => $target,
+                }
             }
         } else {
-            file { "sslcert-${bundlefile}":
-                ensure => $ensure,
-                name   => "${::sslcert::params::certdir}/${bundlefile}",
-                source => "puppet:///files/${bundlefile}", # lint:ignore:puppet_url_without_modules
-
-                owner  => $::sslcert::params::owner,
-                group  => $::sslcert::params::cert_group,
-                mode   => $::sslcert::params::cert_mode,
-
+            if $bundlefile_content {
+                file { "sslcert-${bundlefile}":
+                    name    => "${::sslcert::params::certdir}/${bundlefile}",
+                    content => $bundlefile_content,
+                    *       => $certfile_attr,
+                }
+            } else {
+                file { "sslcert-${bundlefile}":
+                    name   => "${::sslcert::params::certdir}/${bundlefile}",
+                    source => "puppet:///files/${bundlefile}", # lint:ignore:puppet_url_without_modules
+                    *      => $certfile_attr,
+                }
             }
-            file { "sslcert-${certfile}":
-                ensure => $ensure,
-                name   => "${::sslcert::params::certdir}/${certfile}",
-                source => "puppet:///files/sslcert-${certfile}", # lint:ignore:puppet_url_without_modules
-
-                owner  => $::sslcert::params::owner,
-                group  => $::sslcert::params::cert_group,
-                mode   => $::sslcert::params::cert_mode,
-            }
-        }
-    } else {
-        file { "sslcert-${certfile}":
-            ensure => $ensure,
-            name   => "${::sslcert::params::certdir}/${certfile}",
-            source => "puppet:///files/sslcert-${certfile}", # lint:ignore:puppet_url_without_modules
-            owner  => $::sslcert::params::owner,
-            group  => $::sslcert::params::cert_group,
-            mode   => $::sslcert::params::cert_mode,
         }
     }
 }

--- a/spec/defines/set_spec.rb
+++ b/spec/defines/set_spec.rb
@@ -22,6 +22,36 @@ describe 'sslcert::set' do
       it { is_expected.to contain_file('sslcert-example.org.crt').with('source' => 'puppet:///files/sslcert-example.org.crt') }
     end
 
+    context "adds key by content on #{os}" do
+      let(:params) { { 'ensure' => 'present', 'bundlefile' => nil, 'keyfile_content' => 'KEYFILE' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('content' => 'KEYFILE') }
+
+      it { is_expected.to contain_file('sslcert-example.org.crt').with('source' => 'puppet:///files/sslcert-example.org.crt') }
+    end
+
+    context "adds cert by content on #{os}" do
+      let(:params) { { 'ensure' => 'present', 'bundlefile' => nil, 'certfile_content' => 'CERTFILE' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('source' => 'puppet:///files/sslcert-example.org.key') }
+
+      it { is_expected.to contain_file('sslcert-example.org.crt').with('content' => 'CERTFILE') }
+    end
+
+    context "adds cert and key by content on #{os}" do
+      let(:params) { { 'ensure' => 'present', 'bundlefile' => nil, 'certfile_content' => 'CERTFILE', 'keyfile_content' => 'KEYFILE' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('content' => 'KEYFILE') }
+
+      it { is_expected.to contain_file('sslcert-example.org.crt').with('content' => 'CERTFILE') }
+    end
+
     context "adds certs and bundle on #{os}" do
       let(:params) { { 'ensure' => 'present', 'bundlefile' => 'ca.pem', 'embed_bundle' => false } }
 
@@ -34,6 +64,37 @@ describe 'sslcert::set' do
       it { is_expected.to contain_file('sslcert-ca.pem').with('source' => 'puppet:///files/ca.pem') }
     end
 
+    context "adds certs and bundle by content on #{os}" do
+      let(:params) do
+        { 'ensure' => 'present',
+          'bundlefile' => 'ca.pem',
+          'embed_bundle' => false,
+          'certfile_content' => 'CERTFILE',
+          'keyfile_content' => 'KEYFILE',
+          'bundlefile_content' => 'BUNDLEFILE' }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('content' => 'KEYFILE') }
+
+      it { is_expected.to contain_file('sslcert-example.org.crt').with('content' => 'CERTFILE') }
+
+      it { is_expected.to contain_file('sslcert-ca.pem').with('content' => 'BUNDLEFILE') }
+    end
+
+    context "adds certs and bundle mixed on #{os}" do
+      let(:params) { { 'ensure' => 'present', 'bundlefile' => 'ca.pem', 'embed_bundle' => false, 'bundlefile_content' => 'BUNDLEFILE' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('source' => 'puppet:///files/sslcert-example.org.key') }
+
+      it { is_expected.to contain_file('sslcert-example.org.crt').with('source' => 'puppet:///files/sslcert-example.org.crt') }
+
+      it { is_expected.to contain_file('sslcert-ca.pem').with('content' => 'BUNDLEFILE') }
+    end
+
     context "adds certs with embedded bundle on #{os}" do
       let(:params) { { 'ensure' => 'present', 'bundlefile' => 'ca.pem', 'embed_bundle' => true } }
 
@@ -41,11 +102,52 @@ describe 'sslcert::set' do
 
       it { is_expected.to contain_file('sslcert-example.org.key').with('source' => 'puppet:///files/sslcert-example.org.key') }
 
+      it { is_expected.not_to contain_file('sslcert-example.org.crt') }
+
       it { is_expected.to contain_concat('sslcert-example.org-cert-and-bundle') }
 
       it { is_expected.to contain_concat__fragment('sslcert-example.org-cert').with('source' => 'puppet:///files/sslcert-example.org.crt') }
 
       it { is_expected.to contain_concat__fragment('sslcert-example.org-bundle').with('source' => 'puppet:///files/ca.pem') }
+    end
+
+    context "adds certs with embedded bundle by content on #{os}" do
+      let(:params) do
+        { 'ensure' => 'present',
+          'bundlefile' => 'ca.pem',
+          'embed_bundle' => true,
+          'certfile_content' => 'CERTFILE',
+          'keyfile_content' => 'KEYFILE',
+          'bundlefile_content' => 'BUNDLEFILE' }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('content' => 'KEYFILE') }
+
+      it { is_expected.not_to contain_file('sslcert-example.org.crt') }
+
+      it { is_expected.to contain_concat('sslcert-example.org-cert-and-bundle') }
+
+      it { is_expected.to contain_concat__fragment('sslcert-example.org-cert').with('content' => 'CERTFILE') }
+
+      it { is_expected.to contain_concat__fragment('sslcert-example.org-bundle').with('content' => 'BUNDLEFILE') }
+    end
+
+    context "adds certs with embedded bundle mixed content on #{os}" do
+      let(:params) { { 'ensure' => 'present', 'bundlefile' => 'ca.pem', 'embed_bundle' => true, 'bundlefile_content' => 'BUNDLEFILE' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('source' => 'puppet:///files/sslcert-example.org.key') }
+
+      it { is_expected.not_to contain_file('sslcert-example.org.crt') }
+
+      it { is_expected.to contain_concat('sslcert-example.org-cert-and-bundle') }
+
+      it { is_expected.to contain_concat__fragment('sslcert-example.org-cert').with('source' => 'puppet:///files/sslcert-example.org.crt') }
+
+      it { is_expected.to contain_concat__fragment('sslcert-example.org-bundle').with('content' => 'BUNDLEFILE') }
     end
   end
 end


### PR DESCRIPTION
This allows to retrieve the contents via hiera, e.g. via
hiera-eyaml.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>