### PR TITLE
Support passing certificate, keys and bundles as strings in ::sslcert::set

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,41 @@ files have changed.
 
 # Module usage
 
-First put your certificates to the Puppet fileserver under the "files" 
-directory and name them like this:
+The ::sslcert::set define supports two sources for the the certificate, key and
+CA bundle:
+
+* Parameters (e.g. string from hiera-eyaml)
+* Puppet fileserver
+
+These can also be mixed, so you could get your cert and CA bundle from the
+Puppet fileserver, but the private key from hiera-eyaml, passing it to the
+define as a string.
+
+Using this module from another class is simple:
+
+    include ::sslcert
+    
+    sslcert::set { 'www.domain.com':
+        bundlefile   => 'ca-bundle.crt',
+        embed_bundle => false,
+    }
+
+## Passing certs as paramaters
+
+The relevant parameters in ::sslcert::set are:
+
+* bundlefile: target filename for the bundle
+* bundlefile_content: content of the bundle
+* certfile_content: content of the certificate
+* keyfile_content: content of the keyfile
+
+If any of the content parameters are set, then Puppet does not try to fetch
+that particular file from the Puppet fileserver.
+
+## Getting certs from the Puppet fileserver
+
+To use the Puppet fileserver approach put your certificates to the "files"
+share and name them like this:
 
 * sslcert-${basename}.crt
 * sslcert-${basename}.key
@@ -21,12 +54,10 @@ If you want to install a CA bundle, simply copy it to the "files" directory and
 pass the filename, including the file extension, as the $bundlefile parameter of 
 the ::sslcert::set resource. Next a few examples using Hiera.
 
-You always need to include the main class, unless you create your resources 
-using create_resource functions in site.pp:
+## Automatic resource creation in main class
 
-    include ::sslcert
-
-Install a certificate, key and a separate bundle file (e.g. for apache2).
+The main class does not do anything except support creating resources from a
+hash. To Install a certificate, key and a separate bundle file (e.g. for apache2).
 
     sslcert::sets:
         www.domain.com:
@@ -55,14 +86,4 @@ Example of usage from within a node manifest:
     
     class { '::sslcert':
         sets => $sets,
-    }
-
-Usage from another class, without having the ::sslcert main class as a 
-middleman:
-
-    include ::sslcert
-    
-    sslcert::set { 'www.domain.com':
-        bundlefile   => 'ca-bundle.crt',
-        embed_bundle => false,
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,10 @@ class sslcert::params {
             $owner = 'root'
             $cert_group = 'root'
             $cert_mode = '0644'
-            $private_key_group = 'ssl-cert'
+            $private_key_group = $::lsbdistcodename ? {
+              /(focal)/ => 'root',
+              default   => 'ssl-cert',
+            }
             $private_key_mode = '0640'
         }
         default: {

--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -17,6 +17,15 @@
 # [*bundlefile*]
 #   Full name of the bundle file, including the file extension. For example 
 #   'ca-bundle.crt'. Defaults to undef, meaning that a bundle is not installed.
+# [*bundlefile_content*]
+#   Full content of the bundle file. If not present, the bundle is taken from
+#   puppet:///files/${bundlefile}.
+# [*certfile_content*]
+#   Full content of the certificate. If not present, the certificate is taken from
+#   puppet:///files/sslcert-${title}.crt.
+# [*keyfile_content*]
+#   Full content of the private key. If not present, the key is taken from
+#   puppet:///files/sslcert-${title}.key.
 # [*embed_bundle*]
 #   Whether to combine the bundle with the certificate. Valid values are true 
 #   and false. This must be true for nginx and false for apache2. Defaults to 
@@ -26,6 +35,9 @@ define sslcert::set
 (
     Enum['present','absent'] $ensure = 'present',
     Optional[String]         $bundlefile = undef,
+    Optional[String]         $bundlefile_content = undef,
+    Optional[String]         $certfile_content = undef,
+    Optional[String]         $keyfile_content = undef,
     Boolean                  $embed_bundle = false
 )
 {
@@ -34,19 +46,49 @@ define sslcert::set
     $basename = $title
     $keyfile = "${basename}.key"
     $certfile = "${basename}.crt"
+    $certfile_attr = {
+        'ensure' => $ensure,
+        'owner'  => $::sslcert::params::owner,
+        'group'  => $::sslcert::params::cert_group,
+        'mode'   => $::sslcert::params::cert_mode,
+    }
 
     # The key will always be installed as-is
     file { "sslcert-${keyfile}":
         ensure => $ensure,
         name   => "${::sslcert::params::keydir}/${keyfile}",
-        source => "puppet:///files/sslcert-${keyfile}", # lint:ignore:puppet_url_without_modules
-
         owner  => $::sslcert::params::owner,
         group  => $::sslcert::params::private_key_group,
         mode   => $::sslcert::params::private_key_mode,
     }
+    if $keyfile_content {
+        File["sslcert-${keyfile}"] {
+            content => $keyfile_content,
+        }
+    } else {
+        File["sslcert-${keyfile}"] {
+            source => "puppet:///files/sslcert-${keyfile}", # lint:ignore:puppet_url_without_modules
+        }
+    }
 
-    # We might not need a CA bundle if the existing ones are enough, or if we're 
+    unless $embed_bundle {
+        file { "sslcert-${certfile}":
+            name => "${::sslcert::params::certdir}/${certfile}",
+            *    => $certfile_attr,
+        }
+        if $certfile_content {
+            File["sslcert-${certfile}"] {
+                content => $certfile_content,
+            }
+        } else {
+            File["sslcert-${certfile}"] {
+                source => "puppet:///files/sslcert-${certfile}", # lint:ignore:puppet_url_without_modules
+            }
+        }
+    }
+
+
+    # We might not need a CA bundle if the existing ones are enough, or if we're
     # installing self-signed certificates.
     if $bundlefile {
 
@@ -56,54 +98,52 @@ define sslcert::set
             $target = "sslcert-${basename}-cert-and-bundle"
 
             concat { $target:
-                ensure => $ensure,
-                path   => "${::sslcert::params::certdir}/${certfile}",
-                owner  => $::sslcert::params::owner,
-                group  => $::sslcert::params::cert_group,
-                mode   => $::sslcert::params::cert_mode,
+                path => "${::sslcert::params::certdir}/${certfile}",
+                *    => $certfile_attr,
             }
-            concat::fragment { "sslcert-${basename}-cert":
-                source => "puppet:///files/sslcert-${certfile}", # lint:ignore:puppet_url_without_modules
-
-                # The certificate must be placed at the head
-                order  => '1',
-                target => $target,
+            if $certfile_content {
+                concat::fragment { "sslcert-${basename}-cert":
+                    content => $certfile_content,
+                    # The certificate must be placed at the head
+                    order   => '1',
+                    target  => $target,
+                }
+            } else {
+                concat::fragment { "sslcert-${basename}-cert":
+                    source => "puppet:///files/sslcert-${certfile}", # lint:ignore:puppet_url_without_modules
+                    # The certificate must be placed at the head
+                    order  => '1',
+                    target => $target,
+                }
             }
-            concat::fragment { "sslcert-${basename}-bundle":
-                source => "puppet:///files/${bundlefile}", # lint:ignore:puppet_url_without_modules
+            if $bundlefile_content {
+                concat::fragment { "sslcert-${basename}-bundle":
+                    content => $bundlefile_content,
+                    order   => '2',
+                    target  => $target,
+                }
+            } else {
+                concat::fragment { "sslcert-${basename}-bundle":
+                    source => "puppet:///files/${bundlefile}", # lint:ignore:puppet_url_without_modules
+                    order  => '2',
+                    target => $target,
 
-                order  => '2',
-                target => $target,
+                }
             }
         } else {
-            file { "sslcert-${bundlefile}":
-                ensure => $ensure,
-                name   => "${::sslcert::params::certdir}/${bundlefile}",
-                source => "puppet:///files/${bundlefile}", # lint:ignore:puppet_url_without_modules
-
-                owner  => $::sslcert::params::owner,
-                group  => $::sslcert::params::cert_group,
-                mode   => $::sslcert::params::cert_mode,
-
+            if $bundlefile_content {
+                file { "sslcert-${bundlefile}":
+                    name    => "${::sslcert::params::certdir}/${bundlefile}",
+                    content => $bundlefile_content,
+                    *       => $certfile_attr,
+                }
+            } else {
+                file { "sslcert-${bundlefile}":
+                    name   => "${::sslcert::params::certdir}/${bundlefile}",
+                    source => "puppet:///files/${bundlefile}", # lint:ignore:puppet_url_without_modules
+                    *      => $certfile_attr,
+                }
             }
-            file { "sslcert-${certfile}":
-                ensure => $ensure,
-                name   => "${::sslcert::params::certdir}/${certfile}",
-                source => "puppet:///files/sslcert-${certfile}", # lint:ignore:puppet_url_without_modules
-
-                owner  => $::sslcert::params::owner,
-                group  => $::sslcert::params::cert_group,
-                mode   => $::sslcert::params::cert_mode,
-            }
-        }
-    } else {
-        file { "sslcert-${certfile}":
-            ensure => $ensure,
-            name   => "${::sslcert::params::certdir}/${certfile}",
-            source => "puppet:///files/sslcert-${certfile}", # lint:ignore:puppet_url_without_modules
-            owner  => $::sslcert::params::owner,
-            group  => $::sslcert::params::cert_group,
-            mode   => $::sslcert::params::cert_mode,
         }
     }
 }

--- a/spec/defines/set_spec.rb
+++ b/spec/defines/set_spec.rb
@@ -22,6 +22,36 @@ describe 'sslcert::set' do
       it { is_expected.to contain_file('sslcert-example.org.crt').with('source' => 'puppet:///files/sslcert-example.org.crt') }
     end
 
+    context "adds key by content on #{os}" do
+      let(:params) { { 'ensure' => 'present', 'bundlefile' => nil, 'keyfile_content' => 'KEYFILE' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('content' => 'KEYFILE') }
+
+      it { is_expected.to contain_file('sslcert-example.org.crt').with('source' => 'puppet:///files/sslcert-example.org.crt') }
+    end
+
+    context "adds cert by content on #{os}" do
+      let(:params) { { 'ensure' => 'present', 'bundlefile' => nil, 'certfile_content' => 'CERTFILE' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('source' => 'puppet:///files/sslcert-example.org.key') }
+
+      it { is_expected.to contain_file('sslcert-example.org.crt').with('content' => 'CERTFILE') }
+    end
+
+    context "adds cert and key by content on #{os}" do
+      let(:params) { { 'ensure' => 'present', 'bundlefile' => nil, 'certfile_content' => 'CERTFILE', 'keyfile_content' => 'KEYFILE' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('content' => 'KEYFILE') }
+
+      it { is_expected.to contain_file('sslcert-example.org.crt').with('content' => 'CERTFILE') }
+    end
+
     context "adds certs and bundle on #{os}" do
       let(:params) { { 'ensure' => 'present', 'bundlefile' => 'ca.pem', 'embed_bundle' => false } }
 
@@ -34,6 +64,37 @@ describe 'sslcert::set' do
       it { is_expected.to contain_file('sslcert-ca.pem').with('source' => 'puppet:///files/ca.pem') }
     end
 
+    context "adds certs and bundle by content on #{os}" do
+      let(:params) do
+        { 'ensure' => 'present',
+          'bundlefile' => 'ca.pem',
+          'embed_bundle' => false,
+          'certfile_content' => 'CERTFILE',
+          'keyfile_content' => 'KEYFILE',
+          'bundlefile_content' => 'BUNDLEFILE' }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('content' => 'KEYFILE') }
+
+      it { is_expected.to contain_file('sslcert-example.org.crt').with('content' => 'CERTFILE') }
+
+      it { is_expected.to contain_file('sslcert-ca.pem').with('content' => 'BUNDLEFILE') }
+    end
+
+    context "adds certs and bundle mixed on #{os}" do
+      let(:params) { { 'ensure' => 'present', 'bundlefile' => 'ca.pem', 'embed_bundle' => false, 'bundlefile_content' => 'BUNDLEFILE' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('source' => 'puppet:///files/sslcert-example.org.key') }
+
+      it { is_expected.to contain_file('sslcert-example.org.crt').with('source' => 'puppet:///files/sslcert-example.org.crt') }
+
+      it { is_expected.to contain_file('sslcert-ca.pem').with('content' => 'BUNDLEFILE') }
+    end
+
     context "adds certs with embedded bundle on #{os}" do
       let(:params) { { 'ensure' => 'present', 'bundlefile' => 'ca.pem', 'embed_bundle' => true } }
 
@@ -41,11 +102,52 @@ describe 'sslcert::set' do
 
       it { is_expected.to contain_file('sslcert-example.org.key').with('source' => 'puppet:///files/sslcert-example.org.key') }
 
+      it { is_expected.not_to contain_file('sslcert-example.org.crt') }
+
       it { is_expected.to contain_concat('sslcert-example.org-cert-and-bundle') }
 
       it { is_expected.to contain_concat__fragment('sslcert-example.org-cert').with('source' => 'puppet:///files/sslcert-example.org.crt') }
 
       it { is_expected.to contain_concat__fragment('sslcert-example.org-bundle').with('source' => 'puppet:///files/ca.pem') }
+    end
+
+    context "adds certs with embedded bundle by content on #{os}" do
+      let(:params) do
+        { 'ensure' => 'present',
+          'bundlefile' => 'ca.pem',
+          'embed_bundle' => true,
+          'certfile_content' => 'CERTFILE',
+          'keyfile_content' => 'KEYFILE',
+          'bundlefile_content' => 'BUNDLEFILE' }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('content' => 'KEYFILE') }
+
+      it { is_expected.not_to contain_file('sslcert-example.org.crt') }
+
+      it { is_expected.to contain_concat('sslcert-example.org-cert-and-bundle') }
+
+      it { is_expected.to contain_concat__fragment('sslcert-example.org-cert').with('content' => 'CERTFILE') }
+
+      it { is_expected.to contain_concat__fragment('sslcert-example.org-bundle').with('content' => 'BUNDLEFILE') }
+    end
+
+    context "adds certs with embedded bundle mixed content on #{os}" do
+      let(:params) { { 'ensure' => 'present', 'bundlefile' => 'ca.pem', 'embed_bundle' => true, 'bundlefile_content' => 'BUNDLEFILE' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_file('sslcert-example.org.key').with('source' => 'puppet:///files/sslcert-example.org.key') }
+
+      it { is_expected.not_to contain_file('sslcert-example.org.crt') }
+
+      it { is_expected.to contain_concat('sslcert-example.org-cert-and-bundle') }
+
+      it { is_expected.to contain_concat__fragment('sslcert-example.org-cert').with('source' => 'puppet:///files/sslcert-example.org.crt') }
+
+      it { is_expected.to contain_concat__fragment('sslcert-example.org-bundle').with('content' => 'BUNDLEFILE') }
     end
   end
 end

--- a/spec/defines/set_spec.rb
+++ b/spec/defines/set_spec.rb
@@ -28,16 +28,12 @@ describe 'sslcert::set' do
       it { is_expected.to compile.with_all_deps }
 
       it { is_expected.to contain_file('sslcert-example.org.key').with('content' => 'KEYFILE') }
-
-      it { is_expected.to contain_file('sslcert-example.org.crt').with('source' => 'puppet:///files/sslcert-example.org.crt') }
     end
 
     context "adds cert by content on #{os}" do
       let(:params) { { 'ensure' => 'present', 'bundlefile' => nil, 'certfile_content' => 'CERTFILE' } }
 
       it { is_expected.to compile.with_all_deps }
-
-      it { is_expected.to contain_file('sslcert-example.org.key').with('source' => 'puppet:///files/sslcert-example.org.key') }
 
       it { is_expected.to contain_file('sslcert-example.org.crt').with('content' => 'CERTFILE') }
     end
@@ -102,8 +98,6 @@ describe 'sslcert::set' do
 
       it { is_expected.to contain_file('sslcert-example.org.key').with('source' => 'puppet:///files/sslcert-example.org.key') }
 
-      it { is_expected.not_to contain_file('sslcert-example.org.crt') }
-
       it { is_expected.to contain_concat('sslcert-example.org-cert-and-bundle') }
 
       it { is_expected.to contain_concat__fragment('sslcert-example.org-cert').with('source' => 'puppet:///files/sslcert-example.org.crt') }
@@ -122,10 +116,6 @@ describe 'sslcert::set' do
       end
 
       it { is_expected.to compile.with_all_deps }
-
-      it { is_expected.to contain_file('sslcert-example.org.key').with('content' => 'KEYFILE') }
-
-      it { is_expected.not_to contain_file('sslcert-example.org.crt') }
 
       it { is_expected.to contain_concat('sslcert-example.org-cert-and-bundle') }
 


### PR DESCRIPTION
This build on https://github.com/Puppet-Finland/puppet-sslcert/pull/1, mainly making the Puppet code implementation a bit simpler.