### PR TITLE
Remove hidden dependency on ssl-cert package on Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,10 +19,7 @@ class sslcert::params {
             $owner = 'root'
             $cert_group = 'root'
             $cert_mode = '0644'
-            $private_key_group = $::lsbdistcodename ? {
-              /(focal)/ => 'root',
-              default   => 'ssl-cert',
-            }
+            $private_key_group = 'root'
             $private_key_mode = '0640'
         }
         default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class sslcert::params {
             $cert_group = 'root'
             $cert_mode = '0644'
             $private_key_group = 'root'
-            $private_key_mode = '0640'
+            $private_key_mode = '0600'
         }
         default: {
             fail("Unsupported OS: ${facts['os']['family']}")


### PR DESCRIPTION
Unlike this module previously assumed, the presence of the group "ssl-cert" is
not guaranteed on Debian/Ubuntu. Instead, it gets created by the optional
"ssl-cert" package that "enables unattended installs of packages that need to
create SSL certificates". So, use "root" group instead for private keys.

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>